### PR TITLE
Update Options.py

### DIFF
--- a/collapse/modules/storage/Options.py
+++ b/collapse/modules/storage/Options.py
@@ -133,7 +133,7 @@ general_options = [
     Option("hide_messages", lang.t("options.settings.hide_messages"), bool, False),
     Option("hide_links", lang.t("options.settings.hide_links"), bool, False),
     Option("show_client_version", lang.t("options.settings.show_client_version"), bool, False),
-    Option("discord_rpc", lang.t("options.settings.rpc"), bool, True),
+    Option("discord_rpc", lang.t("options.settings.discord_rich_presence"), bool, True),
     Option("hide_console", lang.t("options.settings.hide_console"), bool, False),
     Option("show_installed", lang.t("options.settings.show_installed"), bool, False),
     Option("language", lang.t("options.settings.language").format(", ".join(lang.languages)), default_value="en"),


### PR DESCRIPTION
edited ```options.settings.rpc``` to be valid  ```options.settings.discord_rich_presence``` to fix the description error
Отредактировано options.settings.rpc, чтобы они стали действительными, options.settings.discord_rich_presence для исправления ошибки с описанием.

было:
![изображение](https://github.com/user-attachments/assets/b3423927-639d-474c-bfef-ddf550e4a9f1)

стало:
![изображение](https://github.com/user-attachments/assets/ea993680-54ff-41e8-b377-294774b6ceb0)
