### PR TITLE
enumeration fix in CLI.PY

### DIFF
--- a/collapse/modules/render/CLI.py
+++ b/collapse/modules/render/CLI.py
@@ -66,30 +66,24 @@ class Selector(Module):
             self.text += f"\n\n{lang.t('cli.no-clients')}!\n"
 
     def make_text(self) -> str:
-        """Creates the text for the selector"""
+        """Creates the text for the selector."""
 
-        text = f"\n[bold]{lang.t('cli.menu-header')}[/]\n"
-        text += "\n".join(
-            f"{i + 1}. {client}" for i, client in enumerate(client_manager.clients)
-        )
-        text += "\n"
+        clients_list = "\n".join(f"{i + 1}. {client}" for i, client in enumerate(client_manager.clients))
 
-        function_lines = [
-            lang.t("cli.settings-menu"),
-            lang.t("cli.configs-menu"),
-            lang.t("cli.select-username"),
-            lang.t("cli.enter-ram"),
-            lang.t("cli.ghost-mode"),
-            lang.t("cli.credits-donators"),
-            lang.t("cli.exit"),
-        ]
+        function_lines = {
+            "Exit": "dark_red",
+            lang.t("cli.settings-menu"): "dark_cyan",
+            lang.t("cli.configs-menu"): "dark_cyan",
+            lang.t("cli.select-username"): "dark_cyan",
+            lang.t("cli.enter-ram"): "dark_cyan",
+            lang.t("cli.ghost-mode"): "dark_cyan",
+            lang.t("cli.credits-donators"): "dark_cyan",
+        }
 
-        text += "".join(
-            Function(line, "dark_red" if line == "Exit" else "dark_cyan").line
-            for line in function_lines
-        )
+        function_text = "".join(Function(line, color).line for line, color in function_lines.items())
 
-        return text
+        return f"\n[bold]{lang.t('cli.menu-header')}[/]\n{clients_list}\n{function_text}"
+    
 
     def refresh_text(self) -> None:
         """Refreshes text property"""

--- a/collapse/modules/render/CLI.py
+++ b/collapse/modules/render/CLI.py
@@ -68,23 +68,30 @@ class Selector(Module):
     def make_text(self) -> str:
         """Creates the text for the selector."""
 
-        clients_list = "\n".join(f"{i + 1}. {client}" for i, client in enumerate(client_manager.clients))
 
-        function_lines = {
-            "Exit": "dark_red",
-            lang.t("cli.settings-menu"): "dark_cyan",
-            lang.t("cli.configs-menu"): "dark_cyan",
-            lang.t("cli.select-username"): "dark_cyan",
-            lang.t("cli.enter-ram"): "dark_cyan",
-            lang.t("cli.ghost-mode"): "dark_cyan",
-            lang.t("cli.credits-donators"): "dark_cyan",
-        }
+        clients_list = "\n".join(f"{i + 2}. {client}" for i, client in enumerate(client_manager.clients))
 
-        function_text = "".join(Function(line, color).line for line, color in function_lines.items())
+
+        function_items = [
+            lang.t("cli.settings-menu"),
+            lang.t("cli.configs-menu"),
+            lang.t("cli.select-username"),
+            lang.t("cli.enter-ram"),
+            lang.t("cli.ghost-mode"),
+            lang.t("cli.credits-donators"),
+            lang.t("cli.exit"),
+        ]
+    
+
+        colors = ["dark_cyan"] * (len(function_items) - 1) + ["red"]
+
+
+        function_text = "\n".join(
+            f"[{color}]{i}.{item}[/]" for i, (item, color) in enumerate(zip(function_items, colors), start=41)
+        )
 
         return f"\n[bold]{lang.t('cli.menu-header')}[/]\n{clients_list}\n{function_text}"
     
-
     def refresh_text(self) -> None:
         """Refreshes text property"""
         self.text = self.make_text()


### PR DESCRIPTION
Fixed function ```make_text``` in ```CLI.py``` that incorectly enumerates menu options on first launch

Details:

on first launch the settings menu enumerate incorectly (ss below)

1rst launch before config.ini is created:
![image](https://github.com/user-attachments/assets/b0ec1f22-9008-4aa4-bb9b-224c8df5138d)
2nd launch AFTER config.ini is created:
![image](https://github.com/user-attachments/assets/3c3d63eb-c0a0-4ff3-a0d5-70e0fffc1ba7)


my fix:
1rst launch before config.ini is created:
![image](https://github.com/user-attachments/assets/a4cf168e-c99d-457c-9e05-bb6c5f847a01)

2nd launch AFTER config.ini is created:
![image](https://github.com/user-attachments/assets/f9718d7d-6915-4a50-a425-f8e9424f021a)
