### PR TITLE
update webkit2gtk requirement from 4.0 to 4.1

### DIFF
--- a/src-tauri/src/core/platform/linux.rs
+++ b/src-tauri/src/core/platform/linux.rs
@@ -2,7 +2,7 @@ use crate::core::error::StartupError;
 
 pub fn check_platform_dependencies() -> Result<(), StartupError> {
     let result = std::process::Command::new("pkg-config")
-        .args(["--print-errors", "webkit2gtk-4.0"])
+        .args(["--print-errors", "webkit2gtk-4.1"])
         .output();
 
     match result {


### PR DESCRIPTION
updated because fedora doesn't uses webkit2gtk <4.1 anymore
works if running via
```
cargo tauri dev
```
<img width="856" height="532" alt="image" src="https://github.com/user-attachments/assets/7b9a5c9f-3d60-49af-8514-19bce04c35e3" />
not sure about release build though, might give an error

